### PR TITLE
Optimize game code by representing pixels with bits instead of ints

### DIFF
--- a/game/cpp/production/include/bit_array_2d.hpp
+++ b/game/cpp/production/include/bit_array_2d.hpp
@@ -1,0 +1,95 @@
+#ifndef BIT_ARRAY_2D_HPP
+#define BIT_ARRAY_2D_HPP
+
+#include <array>
+#include <cassert>
+#include <string.h>
+
+template <std::size_t N> class BitArray2D {
+  public:
+	BitArray2D() : array{} {};
+
+	template <std::size_t R>
+	constexpr BitArray2D(const std::array<std::array<uint8_t, N>, R> &orig_array) : array{} {
+		static_assert(R <= MAX_ROW_SIZE, "Exceed maximum row size supported");
+
+		// Setting column by column is more cache-friendly
+		for (int c = 0; c < N; c++) {
+			for (int r = 0; r < R; r++) {
+				uint8_t b = orig_array[r][c];
+				assert(b == 0 || b == 1);
+				array[c] |= static_cast<uint64_t>(b) << r;
+			}
+		}
+	}
+
+	template <std::size_t R> std::array<std::array<uint8_t, N>, R> to_uint8_array() const {
+		static_assert(R <= MAX_ROW_SIZE, "Exceed maximum row size supported");
+		std::array<std::array<uint8_t, N>, R> frame = {0};
+
+		for (int r = 0; r < R; r++) {
+			for (int c = 0; c < N; c++) {
+				frame[r][c] = get(r, c);
+			}
+		}
+
+		return frame;
+	}
+
+	uint8_t get(const int r, const int c) const {
+		assert(r < MAX_ROW_SIZE);
+		assert(c < N);
+
+		return (array[c] >> r) & 1;
+	}
+
+	void set(const int r, const int c, const uint8_t b) {
+		assert(r < MAX_ROW_SIZE);
+		assert(c < N);
+		assert(b == 0 || b == 1);
+
+		// Clear the bit, then set the bit
+		array[c] &= ~(static_cast<uint64_t>(1) << r);
+		array[c] |= static_cast<uint64_t>(b) << r;
+	}
+
+	// Note: row index 0 correspond to the least significant bit
+	void set_col(int c, uint64_t val) { array[c] = val; }
+
+	uint64_t get_col(int c) const { return array[c]; }
+
+	void clear() { array = {0}; }
+
+	// Each non-zero column is represented by its hex form (maximum 16 chars) + comma. Columns
+	// which are all zeros are grouped together, represented by the format "#n", where n is the
+	// number of zero columns, in hex form.
+	// `buf` must have a size that can store the maximum length of the compressed form
+	// (including '\0') .
+	// For example, the Frame class has MAX_X columns, each with 48 bits (which can be
+	// represented by 12 hex characters). The given buf must have a size at least (12 + 1) *
+	// MAX_X + 1.
+	void compressed_form(char *buf) const {
+		// Start with '\0' so that strlen(buf) is 0
+		buf[0] = '\0';
+		for (int x = 0; x < N; x++) {
+			uint64_t val = get_col(x);
+
+			if (val != 0) {
+				sprintf(buf + strlen(buf), "%lX,", val);
+			} else {
+				int zeros = 1;
+				while (x + zeros < N && get_col(x + zeros) == 0) {
+					zeros++;
+				}
+				sprintf(buf + strlen(buf), "#%X,", zeros);
+				x += zeros - 1;
+			}
+		}
+	}
+
+  private:
+	static constexpr int MAX_ROW_SIZE = 64;
+	std::array<uint64_t, N> array;
+};
+
+#endif // BIT_ARRAY_2D_HPP

--- a/game/cpp/production/include/game.hpp
+++ b/game/cpp/production/include/game.hpp
@@ -1,13 +1,14 @@
 #ifndef GAME_HPP
 #define GAME_HPP
 
+#include "bit_array_2d.hpp"
 #include "constants.hpp"
 #include "dino.hpp"
 #include "obstacle.hpp"
 
 #include <array>
 
-using Frame = std::array<std::array<int, MAX_X>, MAX_Y>;
+using Frame = BitArray2D<MAX_X>;
 
 inline constexpr int DINO_DRAW_Y = MAX_Y - DINO_HEIGHT;
 inline constexpr int CACTUS_DRAW_Y = MAX_Y - CACTUS_HEIGHT;
@@ -26,7 +27,7 @@ class Game {
 	const Frame &get_frame() const;
 
   private:
-	const std::array<std::array<int, DINO_WIDTH>, DINO_HEIGHT> &fetch_dino_sprite();
+	const BitArray2D<DINO_WIDTH> &fetch_dino_sprite();
 	void draw_dino();
 	void draw_dino_death();
 	void draw_small_cactus_with_collision(std::array<int, 2> location);

--- a/game/cpp/production/include/sprites.hpp
+++ b/game/cpp/production/include/sprites.hpp
@@ -1,18 +1,20 @@
 #ifndef SPRITES_HPP
 #define SPRITES_HPP
 
+#include "bit_array_2d.hpp"
 #include "constants.hpp"
 
 #include <array>
 
-extern const std::array<std::array<int, CACTUS_WIDTH>, CACTUS_HEIGHT> SMALL_CACTUS_SPRITE;
-extern const std::array<std::array<int, CACTUS_WIDTH>, CACTUS_HEIGHT> LARGE_CACTUS_SPRITE;
-extern const std::array<std::array<int, BIRD_WIDTH>, BIRD_HEIGHT> BIRD_SPRITE;
-extern const std::array<std::array<int, DINO_WIDTH>, DINO_HEIGHT> DINO_JUMP_SPRITE;
-extern const std::array<std::array<int, DINO_WIDTH>, DINO_HEIGHT> DINO_LEFT_SPRITE;
-extern const std::array<std::array<int, DINO_WIDTH>, DINO_HEIGHT> DINO_RIGHT_SPRITE;
-extern const std::array<std::array<int, DINO_WIDTH>, DINO_HEIGHT> DINO_LEFT_DUCK_SPRITE;
-extern const std::array<std::array<int, DINO_WIDTH>, DINO_HEIGHT> DINO_RIGHT_DUCK_SPRITE;
-extern const std::array<std::array<int, DEAD_EYE_DIAMETER>, DEAD_EYE_DIAMETER> DEAD_EYE_SPRITE;
+// Marked as const instead of constexpr because extern constexpr is not possible
+extern const BitArray2D<CACTUS_WIDTH> SMALL_CACTUS_SPRITE_BIT_ARRAY;
+extern const BitArray2D<CACTUS_WIDTH> LARGE_CACTUS_SPRITE_BIT_ARRAY;
+extern const BitArray2D<BIRD_WIDTH> BIRD_SPRITE_BIT_ARRAY;
+extern const BitArray2D<DINO_WIDTH> DINO_JUMP_SPRITE_BIT_ARRAY;
+extern const BitArray2D<DINO_WIDTH> DINO_LEFT_SPRITE_BIT_ARRAY;
+extern const BitArray2D<DINO_WIDTH> DINO_RIGHT_SPRITE_BIT_ARRAY;
+extern const BitArray2D<DINO_WIDTH> DINO_LEFT_DUCK_SPRITE_BIT_ARRAY;
+extern const BitArray2D<DINO_WIDTH> DINO_RIGHT_DUCK_SPRITE_BIT_ARRAY;
+extern const BitArray2D<DEAD_EYE_DIAMETER> DEAD_EYE_SPRITE_BIT_ARRAY;
 
 #endif // SPRITES_HPP

--- a/game/cpp/production/include/terminal_display.hpp
+++ b/game/cpp/production/include/terminal_display.hpp
@@ -15,6 +15,6 @@
 void init_terminal();
 void reset_terminal();
 char read_key();
-void print_frame(const std::array<std::array<int, MAX_X>, MAX_Y> &frame);
+void print_frame(const std::array<std::array<uint8_t, MAX_X>, MAX_Y> &frame);
 
 #endif // TERMINAL_DISPLAY_HPP

--- a/game/cpp/production/src/game.cpp
+++ b/game/cpp/production/src/game.cpp
@@ -1,9 +1,11 @@
 #include "game.hpp"
+#include "bit_array_2d.hpp"
 #include "constants.hpp"
+#include "dino.hpp"
 #include "sprites.hpp"
 
 Game::Game()
-	: score(0), cooldown_count(0), collision(false), frame({0}), dino(Dino()),
+	: score(0), cooldown_count(0), collision(false), frame(), dino(Dino()),
 	  obs_manager(Obstacle_Manager()) {}
 
 int Game::get_score() { return this->score; }
@@ -40,46 +42,46 @@ void Game::update_obstacles() {
 	}
 }
 
-const std::array<std::array<int, DINO_WIDTH>, DINO_HEIGHT> &Game::fetch_dino_sprite() {
+const BitArray2D<DINO_WIDTH> &Game::fetch_dino_sprite() {
 	switch (this->dino.get_state()) {
 		case Dino_State::RUNNING:
-			return this->dino.get_step() == Step_State::LEFT ? DINO_LEFT_SPRITE : DINO_RIGHT_SPRITE;
+			return this->dino.get_step() == Step_State::LEFT ? DINO_LEFT_SPRITE_BIT_ARRAY
+															 : DINO_RIGHT_SPRITE_BIT_ARRAY;
 		case Dino_State::DUCKING:
-			return this->dino.get_step() == Step_State::LEFT ? DINO_LEFT_DUCK_SPRITE
-															 : DINO_RIGHT_DUCK_SPRITE;
+			return this->dino.get_step() == Step_State::LEFT ? DINO_LEFT_DUCK_SPRITE_BIT_ARRAY
+															 : DINO_RIGHT_DUCK_SPRITE_BIT_ARRAY;
 		case Dino_State::JUMPING:
 		default:
-			return DINO_JUMP_SPRITE;
+			return DINO_JUMP_SPRITE_BIT_ARRAY;
 	}
 }
 
 void Game::draw_dino() {
-	const std::array<std::array<int, DINO_WIDTH>, DINO_HEIGHT> &sprite = fetch_dino_sprite();
+	const BitArray2D<DINO_WIDTH> &sprite = fetch_dino_sprite();
 
 	int y_position = dino.get_y_position();
 	for (int i = 0; i < DINO_WIDTH; ++i) {
 		for (int j = 0; j < DINO_HEIGHT; ++j) {
-			frame[DINO_DRAW_Y + j - y_position][i] = sprite[j][i];
+			frame.set(DINO_DRAW_Y + j - y_position, i, sprite.get(j, i));
 		}
 	}
 }
 
 void Game::draw_dino_death() {
-	const std::array<std::array<int, DEAD_EYE_DIAMETER>, DEAD_EYE_DIAMETER> &sprite =
-		DEAD_EYE_SPRITE;
+	const BitArray2D<DEAD_EYE_DIAMETER> &sprite = DEAD_EYE_SPRITE_BIT_ARRAY;
 
 	// Only modification for dino sprite when dead is the eye
 	int dead_eye_y = dino.get_state() == DEAD ? DEAD_EYE_Y : DEAD_DUCK_EYE_Y;
 	int y_position = dino.get_y_position();
 	for (int i = 0; i < DEAD_EYE_DIAMETER; ++i) {
 		for (int j = 0; j < DEAD_EYE_DIAMETER; ++j) {
-			frame[DINO_DRAW_Y + dead_eye_y + j - y_position][DEAD_EYE_X + i] = sprite[j][i];
+			frame.set(DINO_DRAW_Y + +dead_eye_y + j - y_position, DEAD_EYE_X + i, sprite.get(j, i));
 		}
 	}
 }
 
 void Game::draw_small_cactus_with_collision(std::array<int, 2> location) {
-	const std::array<std::array<int, CACTUS_WIDTH>, CACTUS_HEIGHT> &sprite = SMALL_CACTUS_SPRITE;
+	const auto &bit_array = SMALL_CACTUS_SPRITE_BIT_ARRAY;
 
 	for (int i = 0; i < CACTUS_WIDTH; ++i) {
 		if (i + location[0] >= MAX_X || i + location[0] <= 0) {
@@ -87,18 +89,18 @@ void Game::draw_small_cactus_with_collision(std::array<int, 2> location) {
 		}
 
 		for (int j = 0; j < CACTUS_HEIGHT; ++j) {
-			if (sprite[j][i]) {
-				if (frame[CACTUS_DRAW_Y + j - location[1]][i + location[0]] == 1) {
+			if (bit_array.get(j, i)) {
+				if (frame.get(CACTUS_DRAW_Y + j - location[1], i + location[0]) == 1) {
 					this->collision = true;
 				}
-				frame[CACTUS_DRAW_Y + j - location[1]][i + location[0]] = sprite[j][i];
+				frame.set(CACTUS_DRAW_Y + j - location[1], i + location[0], bit_array.get(j, i));
 			}
 		}
 	}
 }
 
 void Game::draw_large_cactus_with_collision(std::array<int, 2> location) {
-	const std::array<std::array<int, CACTUS_WIDTH>, CACTUS_HEIGHT> &sprite = LARGE_CACTUS_SPRITE;
+	const auto &bit_array = LARGE_CACTUS_SPRITE_BIT_ARRAY;
 
 	for (int i = 0; i < CACTUS_WIDTH; ++i) {
 		if (i + location[0] >= MAX_X || i + location[0] <= 0) {
@@ -106,18 +108,18 @@ void Game::draw_large_cactus_with_collision(std::array<int, 2> location) {
 		}
 
 		for (int j = 0; j < CACTUS_HEIGHT; ++j) {
-			if (sprite[j][i]) {
-				if (frame[CACTUS_DRAW_Y + j - location[1]][i + location[0]] == 1) {
+			if (bit_array.get(j, i)) {
+				if (frame.get(CACTUS_DRAW_Y + j - location[1], i + location[0]) == 1) {
 					this->collision = true;
 				}
-				frame[CACTUS_DRAW_Y + j - location[1]][i + location[0]] = sprite[j][i];
+				frame.set(CACTUS_DRAW_Y + j - location[1], i + location[0], bit_array.get(j, i));
 			}
 		}
 	}
 }
 
 void Game::draw_bird_with_collision(std::array<int, 2> location) {
-	const std::array<std::array<int, BIRD_WIDTH>, BIRD_HEIGHT> &sprite = BIRD_SPRITE;
+	const auto &bit_array = BIRD_SPRITE_BIT_ARRAY;
 
 	for (int i = 0; i < BIRD_WIDTH; ++i) {
 		if (i + location[0] >= MAX_X || i + location[0] <= 0) {
@@ -125,18 +127,18 @@ void Game::draw_bird_with_collision(std::array<int, 2> location) {
 		}
 
 		for (int j = 0; j < BIRD_HEIGHT; ++j) {
-			if (sprite[j][i]) {
-				if (frame[BIRD_DRAW_Y + j - location[1]][i + location[0]] == 1) {
+			if (bit_array.get(j, i)) {
+				if (frame.get(BIRD_DRAW_Y + j - location[1], i + location[0]) == 1) {
 					this->collision = true;
 				}
-				frame[BIRD_DRAW_Y + j - location[1]][i + location[0]] = sprite[j][i];
+				frame.set(BIRD_DRAW_Y + j - location[1], i + location[0], bit_array.get(j, i));
 			}
 		}
 	}
 }
 
 void Game::update_frame() {
-	frame = {0};
+	frame.clear();
 
 	draw_dino();
 

--- a/game/cpp/production/src/main.cpp
+++ b/game/cpp/production/src/main.cpp
@@ -37,6 +37,14 @@ bool player_quit() {
 	return false;
 }
 
+void print_compressed_frame(Frame frame) {
+	// Each column (uint64_t) takes at most 13 characters (16 - 4 for hex, 1 for comma)
+	// 1 additional character for '\0'
+	char buf[MAX_X * 13 + 1] = {0};
+	frame.compressed_form(buf);
+	std::cout << buf << std::endl;
+}
+
 int main() {
 	Game game = Game();
 	init_terminal();
@@ -47,15 +55,22 @@ int main() {
 		player_input(game);
 		game.update_obstacles();
 		game.update_frame();
-		print_frame(game.get_frame());
+		// print_frame(game.get_frame().to_uint8_array<MAX_Y>());
+		print_compressed_frame(game.get_frame());
 		usleep(SPEED);
 	}
+	// If piping output to python script, we don't expect any player input from terminal
+	// So we sleep for 1 second (to see the death screen) then quit the program.
+	// This is done before printing the score as the python script terminates right after that.
+	sleep(5);
+	quit = true;
+
 	std::cout << "Score: " << game.get_score() << "\n";
 	std::cout << "Press Q to quit!\n";
 
-	while (!quit) {
-		quit = player_quit();
-	}
+	// while (!quit) {
+	// 	quit = player_quit();
+	// }
 
 	input_thread.join();
 	reset_terminal();

--- a/game/cpp/production/src/sprites.cpp
+++ b/game/cpp/production/src/sprites.cpp
@@ -1,6 +1,8 @@
 #include "sprites.hpp"
+#include "bit_array_2d.hpp"
+#include "constants.hpp"
 
-const std::array<std::array<int, CACTUS_WIDTH>, CACTUS_HEIGHT> SMALL_CACTUS_SPRITE = {
+constexpr std::array<std::array<uint8_t, CACTUS_WIDTH>, CACTUS_HEIGHT> SMALL_CACTUS_SPRITE = {
 	{{{0, 0, 0, 0, 0, 0, 0, 0}},
 	 {{0, 0, 0, 0, 0, 0, 0, 0}},
 	 {{0, 0, 0, 0, 0, 0, 0, 0}},
@@ -15,8 +17,9 @@ const std::array<std::array<int, CACTUS_WIDTH>, CACTUS_HEIGHT> SMALL_CACTUS_SPRI
 	 {{0, 1, 1, 1, 1, 0, 0, 0}},
 	 {{0, 0, 0, 1, 1, 0, 0, 0}},
 	 {{0, 0, 0, 1, 1, 0, 0, 0}}}};
+constexpr BitArray2D<CACTUS_WIDTH> SMALL_CACTUS_SPRITE_BIT_ARRAY(SMALL_CACTUS_SPRITE);
 
-const std::array<std::array<int, CACTUS_WIDTH>, CACTUS_HEIGHT> LARGE_CACTUS_SPRITE = {
+constexpr std::array<std::array<uint8_t, CACTUS_WIDTH>, CACTUS_HEIGHT> LARGE_CACTUS_SPRITE = {
 	{{{0, 0, 0, 1, 1, 0, 0, 0}},
 	 {{0, 0, 0, 1, 1, 0, 0, 0}},
 	 {{0, 0, 0, 1, 1, 0, 1, 1}},
@@ -31,8 +34,9 @@ const std::array<std::array<int, CACTUS_WIDTH>, CACTUS_HEIGHT> LARGE_CACTUS_SPRI
 	 {{0, 1, 1, 1, 1, 1, 0, 0}},
 	 {{0, 0, 0, 1, 1, 1, 0, 0}},
 	 {{0, 0, 0, 1, 1, 1, 0, 0}}}};
+constexpr BitArray2D<CACTUS_WIDTH> LARGE_CACTUS_SPRITE_BIT_ARRAY(LARGE_CACTUS_SPRITE);
 
-const std::array<std::array<int, BIRD_WIDTH>, BIRD_HEIGHT> BIRD_SPRITE = {{
+constexpr std::array<std::array<uint8_t, BIRD_WIDTH>, BIRD_HEIGHT> BIRD_SPRITE = {{
 	{{0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0}},
 	{{0, 0, 0, 1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0}},
 	{{0, 0, 1, 1, 1, 0, 0, 1, 1, 0, 0, 0, 0, 0}},
@@ -43,8 +47,9 @@ const std::array<std::array<int, BIRD_WIDTH>, BIRD_HEIGHT> BIRD_SPRITE = {{
 	{{0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0}},
 	{{0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0}},
 }};
+constexpr BitArray2D<BIRD_WIDTH> BIRD_SPRITE_BIT_ARRAY(BIRD_SPRITE);
 
-const std::array<std::array<int, DINO_WIDTH>, DINO_HEIGHT> DINO_JUMP_SPRITE = {{
+constexpr std::array<std::array<uint8_t, DINO_WIDTH>, DINO_HEIGHT> DINO_JUMP_SPRITE = {{
 	{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0}},
 	{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1}},
 	{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1}},
@@ -66,8 +71,9 @@ const std::array<std::array<int, DINO_WIDTH>, DINO_HEIGHT> DINO_JUMP_SPRITE = {{
 	{{0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0}},
 	{{0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0}},
 }};
+constexpr BitArray2D<DINO_WIDTH> DINO_JUMP_SPRITE_BIT_ARRAY(DINO_JUMP_SPRITE);
 
-const std::array<std::array<int, DINO_WIDTH>, DINO_HEIGHT> DINO_LEFT_SPRITE = {{
+constexpr std::array<std::array<uint8_t, DINO_WIDTH>, DINO_HEIGHT> DINO_LEFT_SPRITE = {{
 	{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0}},
 	{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1}},
 	{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1}},
@@ -89,8 +95,9 @@ const std::array<std::array<int, DINO_WIDTH>, DINO_HEIGHT> DINO_LEFT_SPRITE = {{
 	{{0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
 	{{0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
 }};
+constexpr BitArray2D<DINO_WIDTH> DINO_LEFT_SPRITE_BIT_ARRAY(DINO_LEFT_SPRITE);
 
-const std::array<std::array<int, DINO_WIDTH>, DINO_HEIGHT> DINO_RIGHT_SPRITE = {{
+constexpr std::array<std::array<uint8_t, DINO_WIDTH>, DINO_HEIGHT> DINO_RIGHT_SPRITE = {{
 	{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0}},
 	{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1}},
 	{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1}},
@@ -112,8 +119,9 @@ const std::array<std::array<int, DINO_WIDTH>, DINO_HEIGHT> DINO_RIGHT_SPRITE = {
 	{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0}},
 	{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0}},
 }};
+constexpr BitArray2D<DINO_WIDTH> DINO_RIGHT_SPRITE_BIT_ARRAY(DINO_RIGHT_SPRITE);
 
-const std::array<std::array<int, DINO_WIDTH>, DINO_HEIGHT> DINO_LEFT_DUCK_SPRITE = {{
+constexpr std::array<std::array<uint8_t, DINO_WIDTH>, DINO_HEIGHT> DINO_LEFT_DUCK_SPRITE = {{
 	{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
 	{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
 	{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
@@ -135,8 +143,9 @@ const std::array<std::array<int, DINO_WIDTH>, DINO_HEIGHT> DINO_LEFT_DUCK_SPRITE
 	{{0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
 	{{0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
 }};
+constexpr BitArray2D<DINO_WIDTH> DINO_LEFT_DUCK_SPRITE_BIT_ARRAY(DINO_LEFT_DUCK_SPRITE);
 
-const std::array<std::array<int, DINO_WIDTH>, DINO_HEIGHT> DINO_RIGHT_DUCK_SPRITE = {{
+constexpr std::array<std::array<uint8_t, DINO_WIDTH>, DINO_HEIGHT> DINO_RIGHT_DUCK_SPRITE = {{
 	{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
 	{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
 	{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
@@ -158,9 +167,11 @@ const std::array<std::array<int, DINO_WIDTH>, DINO_HEIGHT> DINO_RIGHT_DUCK_SPRIT
 	{{0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
 	{{0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
 }};
+constexpr BitArray2D<DINO_WIDTH> DINO_RIGHT_DUCK_SPRITE_BIT_ARRAY(DINO_RIGHT_DUCK_SPRITE);
 
-const std::array<std::array<int, DEAD_EYE_DIAMETER>, DEAD_EYE_DIAMETER> DEAD_EYE_SPRITE = {{
+constexpr std::array<std::array<uint8_t, DEAD_EYE_DIAMETER>, DEAD_EYE_DIAMETER> DEAD_EYE_SPRITE = {{
 	{{0, 0, 0}},
 	{{0, 1, 0}},
 	{{0, 0, 0}},
 }};
+constexpr BitArray2D<DEAD_EYE_DIAMETER> DEAD_EYE_SPRITE_BIT_ARRAY(DEAD_EYE_SPRITE);

--- a/game/cpp/production/src/terminal_display.cpp
+++ b/game/cpp/production/src/terminal_display.cpp
@@ -10,7 +10,7 @@ struct termios orig_termios;
 void die(const char *s);
 void reset_terminal();
 
-void print_frame(const std::array<std::array<int, MAX_X>, MAX_Y> &frame) {
+void print_frame(const std::array<std::array<uint8_t, MAX_X>, MAX_Y> &frame) {
 	// Note that the █ character takes two bytes to store, so the buffer length
 	// needs to be big
 	const int BUF_LEN = MAX_Y * MAX_X * 3;

--- a/game/python/compressed_frame_parser.py
+++ b/game/python/compressed_frame_parser.py
@@ -1,0 +1,98 @@
+# This script is adpated from dino_jump_main.py, but is much simpler as all it does is parse lines
+# of strings from stdin, convert them into frames, and show frames using pygame.
+import sys
+import numpy as np
+import pygame
+
+
+class Game:
+
+    def __init__(self):
+
+        # Editable Constants
+        self.GRID_SIZE = 4  # scale entire pygame panel size (only for online display)
+        self.WIDTH, self.HEIGHT = (
+            150,
+            48,
+        )  # define pixel height and width for actual board
+
+        # Non-Editable Constants
+        self.BG_COLOR = (255, 255, 255)  # white colour (background)
+        self.BLOCK_COLOR = (0, 0, 0)  # black colour (sprites)
+        self.FPS = 60  # frames per second frames update
+        self.game_over = False
+
+        # Setup Display
+        self.full_game_state_array = np.zeros((self.HEIGHT, self.WIDTH)).astype(int)
+        self.screen = pygame.display.set_mode(
+            (self.WIDTH * self.GRID_SIZE, self.HEIGHT * self.GRID_SIZE)
+        )
+        self.clk = pygame.time.Clock()
+        pygame.display.set_caption("DinoJump!")
+
+    def parse_frame_string(self):
+        self.full_game_state_array = np.zeros((self.HEIGHT, self.WIDTH), dtype=int)
+        try:
+            s = input()
+        except EOFError as e:
+            print("error: ", e)
+            sys.exit(1)
+        print(s)
+
+        if "Score" in s:
+            self.game_over = True
+            return
+
+        tokens = s.split(",")
+        col = 0
+
+        # We skip the last token as we expect a comma in the end
+        for t in tokens[:-1]:
+            if col >= self.WIDTH:
+                print("unexpected token")
+                sys.exit(1)
+
+            if t[0] == "#":
+                cols = int(t[1:], 16)
+                for _ in range(cols):
+                    self.full_game_state_array[:, col] = 0
+                    col += 1
+            else:
+                binary_str = format(int(t, 16), "048b")
+                binary_array = np.array([int(bit) for bit in binary_str])
+                self.full_game_state_array[:, col] = binary_array.reshape(
+                    -1, 1
+                ).flatten()[::-1]
+                col += 1
+
+    def draw_to_screen(self):
+        # Reset the current board
+        self.screen.fill(game.BG_COLOR)
+        # Use GRID_SIZE to increase the software viewing panel
+        draw_array = np.repeat(
+            np.repeat(self.full_game_state_array, self.GRID_SIZE, axis=0),
+            self.GRID_SIZE,
+            axis=1,
+        )
+        # For each pixel in the game board, draw them in black and white to the screen
+        for row in range(draw_array.shape[0]):
+            for col in range(draw_array.shape[1]):
+                if draw_array[row, col] == 1:
+                    pygame.draw.rect(
+                        self.screen,
+                        self.BLOCK_COLOR,
+                        (col, row, 1, 1),
+                    )
+        pygame.display.flip()
+        self.clk.tick(self.FPS)
+
+
+game = Game()
+
+pygame.init()
+
+while not game.game_over:
+    game.parse_frame_string()
+    game.draw_to_screen()
+
+print("game over!")


### PR DESCRIPTION
Represent pixels with bits. Also proposed a compressed string format for this representation.

The main motivations for this change:
* Allow frames to be transmitted through Serial from ESP32 Nano to Laptop, so that we can confirm the game is running properly on ESP32
  * The compressed string is ~400 characters long. With a baud rate like 115200, the frame rate should be acceptable
* Avoid the "frame to int" conversion needed when flashing the LEDs. Now we can just get the column as a `uint64_t`, and shove the bits in
* Save memory and improve performance (though probably nothing significant)


The easiest way to see this in effect is to compile the `DinoJump` binary, then run
```
./DinoJump | python compressed_frame_parser.py
```
The binary serves as a back end that compresses the frame, while the python program parses the strings and shows the frame with pygame.

This is the first time I am using C++ templates lol, so forgive me if everything is pretty messy. 

Also Perhaps it is a good idea to squash the commits into 1?
Also I may have forgotten to run ci. I'll do that later.
Also I am not too sure if things are properly named and going to the right places. Let me know if there are suggestions.